### PR TITLE
Improve UI around venue leasing and membership

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Booking – Bjørkvang forsamlingslokale og Helgøens Vel</title>
+    <title>Leie lokalet – Bjørkvang forsamlingslokale og Helgøens Vel</title>
     <link rel="icon" href="images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
@@ -29,7 +29,7 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html" aria-current="page">Booking</a></li>
+                    <li><a href="booking.html" aria-current="page">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie&nbsp;&amp;&nbsp;Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
@@ -44,15 +44,15 @@
         <div class="container hero-inner">
             <div class="hero-content">
                 <span class="hero-eyebrow">Planlegg</span>
-                <h1 id="booking-hero-title">Reserver Bjørkvang forsamlingslokale</h1>
-                <p>Kalenderen under viser oppdatert status for Helgøens Vel sitt forsamlingshus. Velg ønsket dato, legg inn detaljene og få bekreftelse fra styret.</p>
+                <h1 id="booking-hero-title">Lei Bjørkvang forsamlingslokale</h1>
+                <p>Kalenderen viser oppdatert status for Helgøens Vel sitt forsamlingshus. Velg dato, fortell oss om arrangementet og få bekreftelse fra styret.</p>
                 <div class="hero-badges" role="list">
                     <span class="hero-badge" role="listitem">Tilgjengelighet i sanntid</span>
                     <span class="hero-badge" role="listitem">Personlig oppfølging</span>
                     <span class="hero-badge" role="listitem">Fleksible romløsninger</span>
                 </div>
                 <div class="hero-actions">
-                    <a class="button" href="#calendar">Se ledige datoer</a>
+                    <a class="button" href="#calendar">Finn ledige datoer</a>
                     <a class="button secondary" href="produkter.html">Sjekk priser</a>
                 </div>
             </div>
@@ -64,12 +64,50 @@
     </section>
 
     <main class="page-main">
+        <section class="page-section space-gallery-section" aria-labelledby="space-gallery-heading">
+            <div class="container">
+                <div class="section-heading">
+                    <h2 id="space-gallery-heading">Velg rommet som passer</h2>
+                    <p>Få et glimt av lokalene før du sender forespørselen. Alle rom kan kombineres for større arrangementer.</p>
+                </div>
+                <div class="space-gallery" role="list">
+                    <article class="space-card" role="listitem">
+                        <figure>
+                            <img src="images/67A6972D-DA19-4F40-B0AC-0C283E59D9F2.jpeg" alt="Selskapsoppsett i Bjørkvangs store sal">
+                            <figcaption>
+                                <h3>Salen</h3>
+                                <p>Romslig sal med scene, god takhøyde og plass til både langbord og dansegulv.</p>
+                            </figcaption>
+                        </figure>
+                    </article>
+                    <article class="space-card" role="listitem">
+                        <figure>
+                            <img src="images/981ED216-C4FB-45C8-8862-E7A537F76A9A.jpeg" alt="Peisestue med sofaer og varme toner">
+                            <figcaption>
+                                <h3>Peisestua</h3>
+                                <p>Intim stue med peis som passer til mindre selskap, møter og samlinger.</p>
+                            </figcaption>
+                        </figure>
+                    </article>
+                    <article class="space-card" role="listitem">
+                        <figure>
+                            <img src="images/76ee410e-035f-409f-bc0c-025141df694e.png" alt="Kjøkkenbenker og utstyr klart til servering">
+                            <figcaption>
+                                <h3>Kjøkken og servering</h3>
+                                <p>Fullt utstyrt kjøkken med dekketøy og serveringsløsninger for arrangementet ditt.</p>
+                            </figcaption>
+                        </figure>
+                    </article>
+                </div>
+            </div>
+        </section>
+
         <section class="page-section">
             <div class="container booking-layout">
                 <div class="booking-main">
                     <div class="section-heading">
-                        <h2>Reserver ønsket tidspunkt</h2>
-                        <p>Kalenderen viser hvilke datoer som allerede er holdt av. Forespørsler som legges inn her blir lagret i nettleseren din og synliggjort for andre besøkende.</p>
+                        <h2>Hold av ønsket tidspunkt</h2>
+                        <p>Kalenderen viser hvilke datoer som allerede er holdt av. Forespørselen du legger inn lagres lokalt i nettleseren og vises for andre besøkende.</p>
                     </div>
                     <div id="calendar" aria-live="polite"></div>
                     <p class="calendar-note">Velg dato direkte i kalenderen for å fylle ut skjemaet raskere. Dobbeltbooking hindres automatisk.</p>
@@ -97,7 +135,7 @@
             <div class="container">
                 <div class="section-heading">
                     <h2 id="booking-form-heading">Send leieforespørsel</h2>
-                    <p>Fortell oss litt om arrangementet og hva du ønsker å leie. Forespørselen sendes til styret som følger opp med bekreftelse og digital kontrakt.</p>
+                    <p>Fortell oss om arrangementet og hva du ønsker å leie. Styret følger opp med bekreftelse og digital kontrakt.</p>
                 </div>
                 <form id="booking-form">
                     <div class="form-grid">
@@ -239,7 +277,7 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html" aria-current="page">Booking</a></li>
+                    <li><a href="booking.html" aria-current="page">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie &amp; priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html" aria-current="page">Hjem</a></li>
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie&nbsp;&amp;&nbsp;Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
@@ -42,12 +42,12 @@
     <section class="page-hero" aria-labelledby="hero-title">
         <div class="container hero-inner">
             <div class="hero-content">
-                <span class="hero-eyebrow">Velkommen</span>
-                <h1 id="hero-title">Velkommen til Bjørkvang forsamlingslokale og Helgøens Vel</h1>
-                <p>Bjørkvang er det varme hjertet på Helgøya – et fleksibelt forsamlingslokale hvor små og store anledninger får et hjemlig preg. Hos oss finner du alt du trenger for møter, feiringer og gode opplevelser.</p>
+                <span class="hero-eyebrow">Forsamlingshuset på Helgøya</span>
+                <h1 id="hero-title">Opplev Bjørkvang forsamlingslokale</h1>
+                <p>Bjørkvang er Helgøens samlingspunkt. Lei lokalet til feiring, kurs eller konsert – eller bli med i fellesskapet som holder huset levende.</p>
                 <div class="hero-actions">
-                    <a class="button" href="booking.html">Book lokalet</a>
-                    <a class="button secondary" href="medlemskap.html">Utforsk medlemskap</a>
+                    <a class="button accent" href="medlemskap.html">Bli medlem i Helgøens Vel</a>
+                    <a class="button secondary" href="booking.html">Lei Bjørkvang</a>
                 </div>
             </div>
             <figure class="hero-media">
@@ -58,19 +58,35 @@
     </section>
 
     <main class="page-main">
+        <section class="page-section membership-highlight" aria-labelledby="membership-highlight-title">
+            <div class="container">
+                <div class="membership-card">
+                    <div class="membership-card__content">
+                        <p class="eyebrow" id="membership-highlight-title">Støtt lokalet</p>
+                        <h2>Medlemskap som gir mer</h2>
+                        <p>Som medlem bidrar du til vedlikehold, får rabatter på leie og blir invitert til egne medlemsarrangementer.</p>
+                    </div>
+                    <div class="membership-card__actions">
+                        <a class="button" href="medlemskap.html">Se medlemsfordelene</a>
+                        <a class="button ghost" href="kontakt.html">Still spørsmål til styret</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <section class="page-section">
             <div class="container">
                 <div class="section-heading">
                     <h2>Om Bjørkvang</h2>
-                    <p>Forsamlingshuset vårt rommer både tradisjon og nytenkning. Vi legger til rette for alt fra intime møter i peisestua til store selskap i salen.</p>
+                    <p>Forsamlingshuset rommer både tradisjon og nytenkning. Vi tilpasser peisestue, sal og kjøkken til arrangementet ditt.</p>
                 </div>
                 <ul class="feature-list" aria-label="Nøkkelpunkter om Bjørkvang">
-                    <li>Praktisk beliggenhet på Helgøya med kort vei til naturen.</li>
-                    <li>Moderne fasiliteter og fleksible romløsninger for ulike behov.</li>
-                    <li>Et aktivt fellesskap som skaper arrangementer og dugnader gjennom året.</li>
+                    <li>Naturskjønn beliggenhet på Helgøya med enkel adkomst.</li>
+                    <li>Fleksible romløsninger for møter, selskap og kultur.</li>
+                    <li>Et aktivt fellesskap med arrangementer og dugnader året rundt.</li>
                 </ul>
                 <div class="action-row">
-                    <a class="button ghost" href="booking.html">Se bookingkalender</a>
+                    <a class="button ghost" href="booking.html">Se kalender for leie</a>
                     <a class="button ghost" href="regler.html">Les regler og branninstruks</a>
                     <a class="button ghost" href="kontakt.html">Ta kontakt med styret</a>
                 </div>
@@ -117,7 +133,7 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie &amp; priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>

--- a/kontakt.html
+++ b/kontakt.html
@@ -28,7 +28,7 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie&nbsp;&amp;&nbsp;Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
@@ -66,7 +66,7 @@
                 </div>
                 <div class="info-grid">
                     <article class="info-card">
-                        <h3>Booking og utleie</h3>
+                        <h3>Leie lokalet</h3>
                         <p>For leieforespørsler kan du bruke <a class="text-link" href="booking.html">bookingskjemaet</a> eller kontakte Trond&nbsp;Bjørnstad direkte.</p>
                         <p><strong>Telefon:</strong> <a href="tel:+4748060273">+47&nbsp;480&nbsp;60&nbsp;273</a></p>
                         <p><strong>E-post:</strong> <a href="mailto:helgoens.vel@example.com">helgoens.vel@example.com</a></p>
@@ -95,7 +95,7 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie &amp; priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>

--- a/medlemskap.html
+++ b/medlemskap.html
@@ -28,7 +28,7 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie&nbsp;&amp;&nbsp;Priser</a></li>
                     <li><a href="medlemskap.html" aria-current="page">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
@@ -113,7 +113,7 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie &amp; priser</a></li>
                     <li><a href="medlemskap.html" aria-current="page">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>

--- a/nyheter.html
+++ b/nyheter.html
@@ -28,7 +28,7 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie&nbsp;&amp;&nbsp;Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
@@ -91,7 +91,7 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie &amp; priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>

--- a/produkter.html
+++ b/produkter.html
@@ -28,7 +28,7 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html" aria-current="page">Leie&nbsp;&amp;&nbsp;Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
@@ -110,7 +110,7 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html" aria-current="page">Leie &amp; priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>

--- a/regler.html
+++ b/regler.html
@@ -28,7 +28,7 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie&nbsp;&amp;&nbsp;Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html" aria-current="page">Regler</a></li>
@@ -189,7 +189,7 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Booking</a></li>
+                    <li><a href="booking.html">Leie lokalet</a></li>
                     <li><a href="produkter.html">Leie &amp; priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html" aria-current="page">Regler</a></li>

--- a/style.css
+++ b/style.css
@@ -299,6 +299,18 @@ button {
     box-shadow: 0 22px 44px rgba(24, 61, 44, 0.18);
 }
 
+.button.accent {
+    background: var(--accent-500);
+    color: var(--text-primary);
+    box-shadow: 0 16px 32px rgba(191, 127, 26, 0.28);
+}
+
+.button.accent:hover,
+.button.accent:focus {
+    background: var(--accent-400);
+    box-shadow: 0 22px 44px rgba(191, 127, 26, 0.3);
+}
+
 .button.secondary {
     background: rgba(37, 120, 90, 0.1);
     color: var(--brand-600);
@@ -334,6 +346,14 @@ button {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
+}
+
+.eyebrow {
+    font-size: 0.85rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: 0 0 0.5rem;
 }
 
 /* Hero */
@@ -550,6 +570,43 @@ button {
     text-decoration: underline;
 }
 
+.membership-highlight {
+    background: linear-gradient(135deg, rgba(37, 120, 90, 0.08), rgba(242, 180, 65, 0.08));
+}
+
+.membership-card {
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-card);
+    padding: clamp(1.8rem, 4vw, 2.6rem);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.membership-card__content {
+    max-width: 46ch;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.membership-card__content h2 {
+    margin: 0;
+}
+
+.membership-card__content p {
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.membership-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
 .callout {
     background: linear-gradient(120deg, rgba(37, 120, 90, 0.95), rgba(242, 180, 65, 0.85));
     color: #fff;
@@ -559,6 +616,56 @@ button {
     display: grid;
     gap: 1rem;
     text-align: center;
+}
+
+.space-gallery-section {
+    background: var(--surface-muted);
+}
+
+.space-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.space-card {
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-card);
+    overflow: hidden;
+    display: grid;
+}
+
+.space-card figure {
+    margin: 0;
+    display: grid;
+    gap: 0;
+}
+
+.space-card img {
+    border-radius: 0;
+    box-shadow: none;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    aspect-ratio: 4 / 3;
+}
+
+.space-card figcaption {
+    padding: 1.25rem 1.5rem 1.5rem;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.space-card h3 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: var(--brand-600);
+}
+
+.space-card p {
+    margin: 0;
+    color: var(--text-secondary);
 }
 
 .products-grid {
@@ -1118,6 +1225,19 @@ button[type="submit"] {
 
     .feature-list li {
         align-items: flex-start;
+    }
+
+    .membership-card {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .membership-card__actions {
+        width: 100%;
+    }
+
+    .space-gallery {
+        grid-template-columns: 1fr;
     }
 
     form {


### PR DESCRIPTION
## Summary
- highlight membership earlier on the homepage with refreshed hero copy and a dedicated call-to-action card
- rename the booking navigation entry to "Leie lokalet" and streamline related copy for clarity
- add a pictured space gallery and supporting styles so each sal has a visual preview on the leasing page

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68de33934a54832593f386b1402fe70d