### PR TITLE
Add placeholders for inventory details and gallery images

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -98,7 +98,73 @@
                             </figcaption>
                         </figure>
                     </article>
+                    <article class="space-card" role="listitem">
+                        <figure>
+                            <span class="placeholder-tag">Plassholder</span>
+                            <img src="https://images.unsplash.com/photo-1522708323590-d24dbb6b0267?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Eksempelbilde av stort selskapslokale med langbord. Erstatt med foto av Bjørkvangs hovedsal.">
+                            <figcaption>
+                                <h3>Hovedsal – eksempel</h3>
+                                <p class="placeholder-note">Eksempelbilde fra Unsplash. Bytt ut med eget bilde av salen og oppdater beskrivelsen.</p>
+                            </figcaption>
+                        </figure>
+                    </article>
+                    <article class="space-card" role="listitem">
+                        <figure>
+                            <span class="placeholder-tag">Plassholder</span>
+                            <img src="https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Eksempelbilde av peisestue med sofaer og peis. Erstatt med foto av Bjørkvangs peisestue.">
+                            <figcaption>
+                                <h3>Peisestue – eksempel</h3>
+                                <p class="placeholder-note">Eksempelbilde fra Unsplash. Legg inn detaljer om møblering og stemning når egne bilder er klare.</p>
+                            </figcaption>
+                        </figure>
+                    </article>
+                    <article class="space-card" role="listitem">
+                        <figure>
+                            <span class="placeholder-tag">Plassholder</span>
+                            <img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Eksempelbilde av profesjonelt kjøkken med benker. Erstatt med foto av Bjørkvangs kjøkken.">
+                            <figcaption>
+                                <h3>Kjøkken – eksempel</h3>
+                                <p class="placeholder-note">Eksempelbilde fra Unsplash. Oppdater teksten med liste over utstyr og kapasitet.</p>
+                            </figcaption>
+                        </figure>
+                    </article>
                 </div>
+            </div>
+        </section>
+
+        <section class="page-section" aria-labelledby="inventory-heading">
+            <div class="container">
+                <div class="section-heading">
+                    <h2 id="inventory-heading">Inventar og utstyr</h2>
+                    <p>Her legger vi inn detaljene om hva som følger med ved leie. Bruk listen under til å fylle ut kjøkkenutstyr, bord og stoler og annet inventar.</p>
+                </div>
+                <div class="inventory-grid">
+                    <article class="inventory-card">
+                        <h3>Kjøkkenutstyr</h3>
+                        <ul>
+                            <li><strong>Oppdateres:</strong> Liste over komfyrer, ovner og oppvaskmaskin.</li>
+                            <li><strong>Legg til:</strong> Antall kjeler, stekepanner, serveringsfat og kaffetraktere.</li>
+                            <li><strong>Noter:</strong> Eventuelle spesialmaskiner (kjøleskap, fryser, isbitmaskin).</li>
+                        </ul>
+                    </article>
+                    <article class="inventory-card">
+                        <h3>Bord og stoler</h3>
+                        <ul>
+                            <li><strong>Oppdateres:</strong> Hvor mange runde og rektangulære bord som er tilgjengelige.</li>
+                            <li><strong>Legg til:</strong> Antall stoler, barstoler og eventuelle barnestoler.</li>
+                            <li><strong>Noter:</strong> Lagerplassering og hvordan bord/stoler lagres etter bruk.</li>
+                        </ul>
+                    </article>
+                    <article class="inventory-card">
+                        <h3>Annet inventar</h3>
+                        <ul>
+                            <li><strong>Oppdateres:</strong> Tekniske hjelpemidler som projektor, lydanlegg og mikrofoner.</li>
+                            <li><strong>Legg til:</strong> Dekorasjoner, duker og lysutstyr som kan lånes.</li>
+                            <li><strong>Noter:</strong> Renholdsutstyr, utendørs møbler og annet praktisk inventar.</li>
+                        </ul>
+                    </article>
+                </div>
+                <p class="inventory-footnote">Marker denne teksten når informasjonen er på plass, eller erstatt med lenke til egen inventarliste.</p>
             </div>
         </section>
 

--- a/style.css
+++ b/style.css
@@ -640,6 +640,7 @@ button {
     margin: 0;
     display: grid;
     gap: 0;
+    position: relative;
 }
 
 .space-card img {
@@ -666,6 +667,69 @@ button {
 .space-card p {
     margin: 0;
     color: var(--text-secondary);
+}
+
+.placeholder-tag {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(37, 120, 90, 0.9);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    box-shadow: 0 10px 18px rgba(24, 61, 44, 0.2);
+}
+
+.placeholder-note {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.inventory-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.inventory-card {
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-card);
+    padding: 1.75rem;
+    display: grid;
+    gap: 1rem;
+    border: 1px solid rgba(37, 120, 90, 0.08);
+}
+
+.inventory-card h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    color: var(--brand-600);
+}
+
+.inventory-card ul {
+    margin: 0;
+    padding-left: 1.25rem;
+    display: grid;
+    gap: 0.65rem;
+    color: var(--text-secondary);
+}
+
+.inventory-card li strong {
+    color: var(--text-primary);
+}
+
+.inventory-footnote {
+    margin-top: 1.5rem;
+    color: var(--text-muted);
+    font-size: 0.95rem;
 }
 
 .products-grid {


### PR DESCRIPTION
## Summary
- add example gallery cards with placeholder badges for each sal so innhold kan byttes senere
- introduce an inventory section with guidance for documenting kjøkkenutstyr, bord og stoler og annet inventar
- style placeholder- og inventar-elementer slik at de matcher eksisterende design

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68df88493a8c8325838fc8f9f924f7ce