### PR TITLE
Oppdater kortnavn for kalender og priser

### DIFF
--- a/booking.html
+++ b/booking.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Kalender & booking – Bjørkvang forsamlingslokale og Helgøens Vel</title>
+    <title>Kalender – Bjørkvang forsamlingslokale og Helgøens Vel</title>
     <link rel="icon" href="images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
@@ -29,8 +29,8 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html" aria-current="page">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser&nbsp;&amp;&nbsp;inventar</a></li>
+                    <li><a href="booking.html" aria-current="page">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                     <li><a href="nyheter.html">Nyheter</a></li>
@@ -357,8 +357,8 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html" aria-current="page">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser &amp; inventar</a></li>
+                    <li><a href="booking.html" aria-current="page">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                 </ul>

--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html" aria-current="page">Hjem</a></li>
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser&nbsp;&amp;&nbsp;inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                     <li><a href="nyheter.html">Nyheter</a></li>
@@ -46,8 +46,8 @@
                 <h1 id="hero-title">Møteplassen midt i Mjøsa</h1>
                 <p>Planlegg arrangementet ditt, engasjer deg i nærmiljøet og finn ut hva Helgøya Vel tilbyr.</p>
                 <div class="hero-actions">
-                    <a class="button accent" href="booking.html">Planlegg arrangement</a>
-                    <a class="button secondary" href="produkter.html">Priser &amp; inventar</a>
+                    <a class="button accent" href="booking.html">Planlegg dato</a>
+                    <a class="button secondary" href="produkter.html">Se priser</a>
                 </div>
             </div>
             <figure class="hero-media">
@@ -86,8 +86,8 @@
                     <li>Et aktivt fellesskap med arrangementer og dugnader året rundt.</li>
                 </ul>
                 <div class="action-row">
-                    <a class="button ghost" href="booking.html">Kalender &amp; booking</a>
-                    <a class="button ghost" href="produkter.html">Priser &amp; inventar</a>
+                    <a class="button ghost" href="booking.html">Kalender</a>
+                    <a class="button ghost" href="produkter.html">Priser</a>
                     <a class="button ghost" href="kontakt.html">Kontakt styret</a>
                 </div>
             </div>
@@ -98,7 +98,7 @@
                 <article class="info-card">
                     <h3>Planlegg ditt arrangement</h3>
                     <p>Skal du arrangere konfirmasjon, bursdag eller møte? Få oversikt over rommene, kapasiteten og praktisk tilrettelegging.</p>
-                    <p><a class="text-link" href="booking.html">Åpne kalender og booking</a></p>
+                    <p><a class="text-link" href="booking.html">Åpne kalender</a></p>
                 </article>
                 <article class="info-card highlight">
                     <h3>Bli med i fellesskapet</h3>
@@ -108,7 +108,7 @@
                 <article class="info-card">
                     <h3>Finn riktig pakke</h3>
                     <p>Velg mellom hele huset, peisestuen eller kjøkkenet. Se hva som følger med og hvordan prisene er satt opp.</p>
-                    <p><a class="text-link" href="produkter.html">Utforsk priser og inventar</a></p>
+                    <p><a class="text-link" href="produkter.html">Utforsk priser</a></p>
                 </article>
             </div>
         </section>
@@ -133,8 +133,8 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser &amp; inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                 </ul>

--- a/kontakt.html
+++ b/kontakt.html
@@ -28,8 +28,8 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser&nbsp;&amp;&nbsp;inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                     <li><a href="nyheter.html">Nyheter</a></li>
@@ -66,7 +66,7 @@
                 </div>
                 <div class="info-grid">
                     <article class="info-card">
-                        <h3>Kalender & booking</h3>
+                        <h3>Kalender</h3>
                         <p>For leieforespørsler bruker du <a class="text-link" href="booking.html">bookingskjemaet</a>. Kontaktperson i styret oppdateres snart.</p>
                         <p><strong>Kontaktperson:</strong> Navn kommer</p>
                         <p><strong>Telefon:</strong> Oppdateres</p>
@@ -96,8 +96,8 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser &amp; inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                 </ul>

--- a/medlemskap.html
+++ b/medlemskap.html
@@ -28,8 +28,8 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser&nbsp;&amp;&nbsp;inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html" aria-current="page">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                     <li><a href="nyheter.html">Nyheter</a></li>
@@ -108,8 +108,8 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser &amp; inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html" aria-current="page">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                 </ul>

--- a/nyheter.html
+++ b/nyheter.html
@@ -28,8 +28,8 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser&nbsp;&amp;&nbsp;inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                     <li><a href="nyheter.html" aria-current="page">Nyheter</a></li>
@@ -91,8 +91,8 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser &amp; inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                 </ul>

--- a/produkter.html
+++ b/produkter.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Priser &amp; inventar – Bjørkvang forsamlingslokale og Helgøens Vel</title>
+    <title>Priser – Bjørkvang forsamlingslokale og Helgøens Vel</title>
     <link rel="icon" href="images/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -28,8 +28,8 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html" aria-current="page">Priser&nbsp;&amp;&nbsp;inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html" aria-current="page">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                     <li><a href="nyheter.html">Nyheter</a></li>
@@ -42,7 +42,7 @@
     <section class="page-hero" aria-labelledby="pricing-title">
         <div class="container hero-inner">
             <div class="hero-content">
-                <span class="hero-eyebrow">Priser &amp; inventar</span>
+                <span class="hero-eyebrow">Priser</span>
                 <h1 id="pricing-title">Finn pakken som passer arrangementet ditt</h1>
                 <p>Velg mellom ulike rom og tilleggstjenester. Prisene inkluderer normal sluttvask og tilgang til grunnleggende teknisk utstyr.</p>
                 <div class="hero-actions">
@@ -110,8 +110,8 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html" aria-current="page">Priser &amp; inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html" aria-current="page">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html">Regler</a></li>
                 </ul>

--- a/regler.html
+++ b/regler.html
@@ -28,8 +28,8 @@
             <nav class="site-nav" id="primary-nav" aria-label="Hovedmeny">
                 <ul>
                     <li><a href="index.html">Hjem</a></li>
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser&nbsp;&amp;&nbsp;inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html" aria-current="page">Regler</a></li>
                     <li><a href="nyheter.html">Nyheter</a></li>
@@ -189,8 +189,8 @@
             <div>
                 <h2 class="footer-title">Snarveier</h2>
                 <ul class="footer-links">
-                    <li><a href="booking.html">Kalender & booking</a></li>
-                    <li><a href="produkter.html">Priser &amp; inventar</a></li>
+                    <li><a href="booking.html">Kalender</a></li>
+                    <li><a href="produkter.html">Priser</a></li>
                     <li><a href="medlemskap.html">Medlemskap</a></li>
                     <li><a href="regler.html" aria-current="page">Regler</a></li>
                 </ul>


### PR DESCRIPTION
## Summary
- shorten the navigation labels to "Kalender" and "Priser" across the public pages
- refresh related hero buttons, link texts, and the pricing page title to match the new wording

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfa4cb43e48325b023d2b9c1574be4