### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -1422,6 +1422,83 @@ button[type="submit"] {
     }
 }
 
+@media (max-width: 600px) {
+    .container {
+        width: min(1120px, calc(100vw - 1.75rem));
+    }
+
+    .nav-container {
+        padding: 0.7rem 0;
+    }
+
+    .site-nav {
+        left: 0;
+        right: 0;
+        margin: 0 0.75rem;
+    }
+
+    .site-nav ul {
+        padding: 0.25rem;
+    }
+
+    .hero-actions,
+    .action-row,
+    .button-group {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .hero-actions .button,
+    .action-row .button,
+    .button-group .button,
+    .button-group .button.secondary,
+    .button-group .button.ghost,
+    .membership-card__actions .button {
+        width: 100%;
+    }
+
+    .membership-card {
+        align-items: stretch;
+    }
+
+    .membership-card__actions {
+        width: 100%;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .feature-list li {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .callout {
+        text-align: left;
+    }
+
+    form {
+        padding: 1.25rem;
+    }
+
+    .form-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .reservation-item {
+        padding: 1rem 1.1rem;
+    }
+
+    .footer-grid {
+        text-align: center;
+    }
+
+    .footer-links,
+    .footer-contact {
+        align-items: center;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     *,
     *::before,


### PR DESCRIPTION
## Summary
- add a mobile breakpoint to stack action areas and buttons for small viewports
- tweak navigation, layout spacing, and footer alignment for handheld screens

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dfc676c0208325a1d2d28cf555a3df